### PR TITLE
Multi node

### DIFF
--- a/scripts/gym_bridge.py
+++ b/scripts/gym_bridge.py
@@ -108,7 +108,7 @@ class GymBridge(object):
 
         # Timer
         self.timer = rospy.Timer(rospy.Duration(0.004), self.timer_callback)
-        self.drive_timer = rospy.Timer(rospy.Duration(0.05), self.drive_timer_callback)
+        self.drive_timer = rospy.Timer(rospy.Duration(0.004), self.drive_timer_callback)
 
     def update_sim_state(self):
         self.ego_scan = list(self.obs['scans'][0])

--- a/scripts/gym_bridge.py
+++ b/scripts/gym_bridge.py
@@ -107,8 +107,8 @@ class GymBridge(object):
         # ts.registerCallback(self.drive_callback)
 
         # Timer
-        self.timer = rospy.Timer(rospy.Duration(0.004), self.timer_callback)
-        self.drive_timer = rospy.Timer(rospy.Duration(0.004), self.drive_timer_callback)
+        self.timer = rospy.Timer(rospy.Duration(0.01), self.timer_callback)
+        self.drive_timer = rospy.Timer(rospy.Duration(0.01), self.drive_timer_callback)
 
     def update_sim_state(self):
         self.ego_scan = list(self.obs['scans'][0])

--- a/scripts/test_timer.py
+++ b/scripts/test_timer.py
@@ -1,0 +1,51 @@
+import unittest
+from gym_bridge import GymBridge
+import rospy, rostopic 
+from nav_msgs.msg import Odometry
+import rostest
+import roslaunch
+
+PKG = 'test_timer'
+
+class TestTimer(unittest.TestCase):
+
+    def callback(self):
+        window = 5000
+        expected_fps = 250  # current setting is to have both timer & drive timer update at 250 Hz (every 0.004s)
+
+        self.published = True
+        self.counter += 1
+        if self.counter==window-1:
+            self.finish_time = rospy.Time.now()
+            dt = (self.finish_time-self.start_time).to_sec()
+            self.fps = window/dt
+            self.assertAlmostEqual(self.fps, expected_fps)      
+
+    def subscribe(self, topic):
+        self.published = False
+        rospy.init_node('test_timer')
+        self.start_time = rospy.Time.now()
+        self.counter = 0
+        rospy.Subscriber(topic, rospy.AnyMsg, self.callback)
+
+    def test_timer_fps(self):
+        topic = '/odom'
+        self.subscribe(topic)
+    
+    def test_drive_timer_fps(self):
+        topic = '/race_info'
+        self.subscribe(topic)
+
+    def test_fps_dummy_agents(self):
+        # roslaunch requires a package 'netifaces' to launch
+        
+        file_path = '../launch/agent_template.launch'
+        uuid = roslaunch.rlutil.get_or_generate_uuid(None, False)
+        roslaunch.configure_logging(uuid)
+        launch = roslaunch.parent.ROSLaunchParent(uuid, [file_path])
+        launch.start()
+        self.test_timer_fps()
+        self.test_drive_timer_fps()
+
+if __name__ == '__main__':
+    rostest.rosrun(PKG, 'test_timer', TestTimer)


### PR DESCRIPTION
Problem description:

- Current behavior: updates at 20 Hz. Tries to get input from both agents, if no update from agents do previous command again. 
- Proposed new behavior: updates at 100 Hz. Same synchronization and zero-order-hold scheme. 
- Why? by taking commands at 20 Hz and running physics at 100 Hz visualizations etc are being displayed at 1/5th of real time
- If you miss a control input at 20 Hz performance suffers. Synchronization is artificial, this alleviates the aliasing problem. 

Solution:

- updated both the self.timer and self.drive_timer rate to 100Hz
- added test script (test_timer.py) that runs three simple tests:
  -- test_timer_fps using /tf or /odom topic
  -- test_drive_timer_fps using /race_info topic
  -- test_fps_dummy_agents, spin up a dummy agent and measure the update rate
