### PR TITLE
corrected docker exec cmd to f1tenth_gym_ros-sim-1 from f1tenth_gym_r…

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ docker-compose up
 ``` 
 4. In a separate terminal, run the following, and you'll have the a bash session in the simulation container. `tmux` is available for convenience.
 ```bash
-$ docker exec -it f1tenth_gym_ros_sim_1 /bin/bash
+$ docker exec -it f1tenth_gym_ros-sim-1 /bin/bash
 ```
 5. In your browser, navigate to [http://localhost:8080/vnc.html](http://localhost:8080/vnc.html), you should see the noVNC logo with the connect button. Click the connect button to connect to the session.
 


### PR DESCRIPTION
corrected the `docker exec -it f1tenth_gym_ros_sim_1 /bin/bash` to `docker exec -it f1tenth_gym_ros-sim-1 /bin/bash` to have the correct container name 
