### PR TITLE
LiDAR scan issue due to position offset

### DIFF
--- a/config/sim.yaml
+++ b/config/sim.yaml
@@ -35,7 +35,7 @@ bridge:
     opp_drive_topic: 'opp_drive'
 
     # transform related
-    scan_distance_to_base_link: 0.0
+    scan_distance_to_base_link: 0.275
     
     # laserscan parameters
     scan_fov: 4.7

--- a/f1tenth_gym_ros/gym_bridge.py
+++ b/f1tenth_gym_ros/gym_bridge.py
@@ -38,89 +38,93 @@ import gym
 import numpy as np
 from transforms3d import euler
 
-
 class GymBridge(Node):
     def __init__(self):
-        super().__init__("gym_bridge")
+        super().__init__('gym_bridge')
 
-        self.declare_parameter("ego_namespace")
-        self.declare_parameter("ego_odom_topic")
-        self.declare_parameter("ego_opp_odom_topic")
-        self.declare_parameter("ego_scan_topic")
-        self.declare_parameter("ego_drive_topic")
-        self.declare_parameter("opp_namespace")
-        self.declare_parameter("opp_odom_topic")
-        self.declare_parameter("opp_ego_odom_topic")
-        self.declare_parameter("opp_scan_topic")
-        self.declare_parameter("opp_drive_topic")
-        self.declare_parameter("scan_distance_to_base_link")
-        self.declare_parameter("scan_fov")
-        self.declare_parameter("scan_beams")
-        self.declare_parameter("map_path")
-        self.declare_parameter("map_img_ext")
-        self.declare_parameter("num_agent")
-        self.declare_parameter("sx")
-        self.declare_parameter("sy")
-        self.declare_parameter("stheta")
-        self.declare_parameter("sx1")
-        self.declare_parameter("sy1")
-        self.declare_parameter("stheta1")
-        self.declare_parameter("kb_teleop")
+        self.declare_parameter('ego_namespace')
+        self.declare_parameter('ego_odom_topic')
+        self.declare_parameter('ego_opp_odom_topic')
+        self.declare_parameter('ego_scan_topic')
+        self.declare_parameter('ego_drive_topic')
+        self.declare_parameter('opp_namespace')
+        self.declare_parameter('opp_odom_topic')
+        self.declare_parameter('opp_ego_odom_topic')
+        self.declare_parameter('opp_scan_topic')
+        self.declare_parameter('opp_drive_topic')
+        self.declare_parameter('scan_distance_to_base_link')
+        self.declare_parameter('scan_fov')
+        self.declare_parameter('scan_beams')
+        self.declare_parameter('map_path')
+        self.declare_parameter('map_img_ext')
+        self.declare_parameter('num_agent')
+        self.declare_parameter('sx')
+        self.declare_parameter('sy')
+        self.declare_parameter('stheta')
+        self.declare_parameter('sx1')
+        self.declare_parameter('sy1')
+        self.declare_parameter('stheta1')
+        self.declare_parameter('kb_teleop')
 
         # check num_agents
-        num_agents = self.get_parameter("num_agent").value
+        num_agents = self.get_parameter('num_agent').value
         if num_agents < 1 or num_agents > 2:
-            raise ValueError("num_agents should be either 1 or 2.")
+            raise ValueError('num_agents should be either 1 or 2.')
         elif type(num_agents) != int:
-            raise ValueError("num_agents should be an int.")
+            raise ValueError('num_agents should be an int.')
 
         # env backend
-        self.env = gym.make("f110_gym:f110-v0", map=self.get_parameter("map_path").value, map_ext=self.get_parameter("map_img_ext").value, num_agents=num_agents, lidar_dist=self.get_parameter("scan_distance_to_base_link").value)
+        self.env = gym.make('f110_gym:f110-v0',
+                            map=self.get_parameter('map_path').value,
+                            map_ext=self.get_parameter('map_img_ext').value,
+                            num_agents=num_agents,
+                            lidar_dist=self.get_parameter("scan_distance_to_base_link").value
+                            )
 
-        sx = self.get_parameter("sx").value
-        sy = self.get_parameter("sy").value
-        stheta = self.get_parameter("stheta").value
+        sx = self.get_parameter('sx').value
+        sy = self.get_parameter('sy').value
+        stheta = self.get_parameter('stheta').value
         self.ego_pose = [sx, sy, stheta]
         self.ego_speed = [0.0, 0.0, 0.0]
         self.ego_requested_speed = 0.0
         self.ego_steer = 0.0
         self.ego_collision = False
-        ego_scan_topic = self.get_parameter("ego_scan_topic").value
-        ego_drive_topic = self.get_parameter("ego_drive_topic").value
-        scan_fov = self.get_parameter("scan_fov").value
-        scan_beams = self.get_parameter("scan_beams").value
-        self.angle_min = -scan_fov / 2.0
-        self.angle_max = scan_fov / 2.0
+        ego_scan_topic = self.get_parameter('ego_scan_topic').value
+        ego_drive_topic = self.get_parameter('ego_drive_topic').value
+        scan_fov = self.get_parameter('scan_fov').value
+        scan_beams = self.get_parameter('scan_beams').value
+        self.angle_min = -scan_fov / 2.
+        self.angle_max = scan_fov / 2.
         self.angle_inc = scan_fov / scan_beams
-        self.ego_namespace = self.get_parameter("ego_namespace").value
-        ego_odom_topic = self.ego_namespace + "/" + self.get_parameter("ego_odom_topic").value
-        self.scan_distance_to_base_link = self.get_parameter("scan_distance_to_base_link").value
-
+        self.ego_namespace = self.get_parameter('ego_namespace').value
+        ego_odom_topic = self.ego_namespace + '/' + self.get_parameter('ego_odom_topic').value
+        self.scan_distance_to_base_link = self.get_parameter('scan_distance_to_base_link').value
+        
         if num_agents == 2:
             self.has_opp = True
-            self.opp_namespace = self.get_parameter("opp_namespace").value
-            sx1 = self.get_parameter("sx1").value
-            sy1 = self.get_parameter("sy1").value
-            stheta1 = self.get_parameter("stheta1").value
+            self.opp_namespace = self.get_parameter('opp_namespace').value
+            sx1 = self.get_parameter('sx1').value
+            sy1 = self.get_parameter('sy1').value
+            stheta1 = self.get_parameter('stheta1').value
             self.opp_pose = [sx1, sy1, stheta1]
             self.opp_speed = [0.0, 0.0, 0.0]
             self.opp_requested_speed = 0.0
             self.opp_steer = 0.0
             self.opp_collision = False
-            self.obs, _, self.done, _ = self.env.reset(np.array([[sx, sy, stheta], [sx1, sy1, stheta1]]))
-            self.ego_scan = list(self.obs["scans"][0])
-            self.opp_scan = list(self.obs["scans"][1])
+            self.obs, _ , self.done, _ = self.env.reset(np.array([[sx, sy, stheta], [sx1, sy1, stheta1]]))
+            self.ego_scan = list(self.obs['scans'][0])
+            self.opp_scan = list(self.obs['scans'][1])
 
-            opp_scan_topic = self.get_parameter("opp_scan_topic").value
-            opp_odom_topic = self.opp_namespace + "/" + self.get_parameter("opp_odom_topic").value
-            opp_drive_topic = self.get_parameter("opp_drive_topic").value
+            opp_scan_topic = self.get_parameter('opp_scan_topic').value
+            opp_odom_topic = self.opp_namespace + '/' + self.get_parameter('opp_odom_topic').value
+            opp_drive_topic = self.get_parameter('opp_drive_topic').value
 
-            ego_opp_odom_topic = self.ego_namespace + "/" + self.get_parameter("ego_opp_odom_topic").value
-            opp_ego_odom_topic = self.opp_namespace + "/" + self.get_parameter("opp_ego_odom_topic").value
+            ego_opp_odom_topic = self.ego_namespace + '/' + self.get_parameter('ego_opp_odom_topic').value
+            opp_ego_odom_topic = self.opp_namespace + '/' + self.get_parameter('opp_ego_odom_topic').value
         else:
             self.has_opp = False
-            self.obs, _, self.done, _ = self.env.reset(np.array([[sx, sy, stheta]]))
-            self.ego_scan = list(self.obs["scans"][0])
+            self.obs, _ , self.done, _ = self.env.reset(np.array([[sx, sy, stheta]]))
+            self.ego_scan = list(self.obs['scans'][0])
 
         # sim physical step timer
         self.drive_timer = self.create_timer(0.01, self.drive_timer_callback)
@@ -142,14 +146,35 @@ class GymBridge(Node):
             self.opp_drive_published = False
 
         # subscribers
-        self.ego_drive_sub = self.create_subscription(AckermannDriveStamped, ego_drive_topic, self.drive_callback, 10)
-        self.ego_reset_sub = self.create_subscription(PoseWithCovarianceStamped, "/initialpose", self.ego_reset_callback, 10)
+        self.ego_drive_sub = self.create_subscription(
+            AckermannDriveStamped,
+            ego_drive_topic,
+            self.drive_callback,
+            10)
+        self.ego_reset_sub = self.create_subscription(
+            PoseWithCovarianceStamped,
+            '/initialpose',
+            self.ego_reset_callback,
+            10)
         if num_agents == 2:
-            self.opp_drive_sub = self.create_subscription(AckermannDriveStamped, opp_drive_topic, self.opp_drive_callback, 10)
-            self.opp_reset_sub = self.create_subscription(PoseStamped, "/goal_pose", self.opp_reset_callback, 10)
+            self.opp_drive_sub = self.create_subscription(
+                AckermannDriveStamped,
+                opp_drive_topic,
+                self.opp_drive_callback,
+                10)
+            self.opp_reset_sub = self.create_subscription(
+                PoseStamped,
+                '/goal_pose',
+                self.opp_reset_callback,
+                10)
 
-        if self.get_parameter("kb_teleop").value:
-            self.teleop_sub = self.create_subscription(Twist, "/cmd_vel", self.teleop_callback, 10)
+        if self.get_parameter('kb_teleop').value:
+            self.teleop_sub = self.create_subscription(
+                Twist,
+                '/cmd_vel',
+                self.teleop_callback,
+                10)
+
 
     def drive_callback(self, drive_msg):
         self.ego_requested_speed = drive_msg.drive.speed
@@ -168,12 +193,12 @@ class GymBridge(Node):
         rqy = pose_msg.pose.pose.orientation.y
         rqz = pose_msg.pose.pose.orientation.z
         rqw = pose_msg.pose.pose.orientation.w
-        _, _, rtheta = euler.quat2euler([rqw, rqx, rqy, rqz], axes="sxyz")
+        _, _, rtheta = euler.quat2euler([rqw, rqx, rqy, rqz], axes='sxyz')
         if self.has_opp:
-            opp_pose = [self.obs["poses_x"][1], self.obs["poses_y"][1], self.obs["poses_theta"][1]]
-            self.obs, _, self.done, _ = self.env.reset(np.array([[rx, ry, rtheta], opp_pose]))
+            opp_pose = [self.obs['poses_x'][1], self.obs['poses_y'][1], self.obs['poses_theta'][1]]
+            self.obs, _ , self.done, _ = self.env.reset(np.array([[rx, ry, rtheta], opp_pose]))
         else:
-            self.obs, _, self.done, _ = self.env.reset(np.array([[rx, ry, rtheta]]))
+            self.obs, _ , self.done, _ = self.env.reset(np.array([[rx, ry, rtheta]]))
 
     def opp_reset_callback(self, pose_msg):
         if self.has_opp:
@@ -183,9 +208,8 @@ class GymBridge(Node):
             rqy = pose_msg.pose.orientation.y
             rqz = pose_msg.pose.orientation.z
             rqw = pose_msg.pose.orientation.w
-            _, _, rtheta = euler.quat2euler([rqw, rqx, rqy, rqz], axes="sxyz")
-            self.obs, _, self.done, _ = self.env.reset(np.array([list(self.ego_pose), [rx, ry, rtheta]]))
-
+            _, _, rtheta = euler.quat2euler([rqw, rqx, rqy, rqz], axes='sxyz')
+            self.obs, _ , self.done, _ = self.env.reset(np.array([list(self.ego_pose), [rx, ry, rtheta]]))
     def teleop_callback(self, twist_msg):
         if not self.ego_drive_published:
             self.ego_drive_published = True
@@ -212,24 +236,24 @@ class GymBridge(Node):
         # pub scans
         scan = LaserScan()
         scan.header.stamp = ts
-        scan.header.frame_id = self.ego_namespace + "/laser"
+        scan.header.frame_id = self.ego_namespace + '/laser'
         scan.angle_min = self.angle_min
         scan.angle_max = self.angle_max
         scan.angle_increment = self.angle_inc
-        scan.range_min = 0.0
-        scan.range_max = 30.0
+        scan.range_min = 0.
+        scan.range_max = 30.
         scan.ranges = self.ego_scan
         self.ego_scan_pub.publish(scan)
 
         if self.has_opp:
             opp_scan = LaserScan()
             opp_scan.header.stamp = ts
-            opp_scan.header.frame_id = self.opp_namespace + "/laser"
+            opp_scan.header.frame_id = self.opp_namespace + '/laser'
             opp_scan.angle_min = self.angle_min
             opp_scan.angle_max = self.angle_max
             opp_scan.angle_increment = self.angle_inc
-            opp_scan.range_min = 0.0
-            opp_scan.range_max = 30.0
+            opp_scan.range_min = 0.
+            opp_scan.range_max = 30.
             opp_scan.ranges = self.opp_scan
             self.opp_scan_pub.publish(opp_scan)
 
@@ -240,31 +264,33 @@ class GymBridge(Node):
         self._publish_wheel_transforms(ts)
 
     def _update_sim_state(self):
-        self.ego_scan = list(self.obs["scans"][0])
+        self.ego_scan = list(self.obs['scans'][0])
         if self.has_opp:
-            self.opp_scan = list(self.obs["scans"][1])
-            self.opp_pose[0] = self.obs["poses_x"][1]
-            self.opp_pose[1] = self.obs["poses_y"][1]
-            self.opp_pose[2] = self.obs["poses_theta"][1]
-            self.opp_speed[0] = self.obs["linear_vels_x"][1]
-            self.opp_speed[1] = self.obs["linear_vels_y"][1]
-            self.opp_speed[2] = self.obs["ang_vels_z"][1]
+            self.opp_scan = list(self.obs['scans'][1])
+            self.opp_pose[0] = self.obs['poses_x'][1]
+            self.opp_pose[1] = self.obs['poses_y'][1]
+            self.opp_pose[2] = self.obs['poses_theta'][1]
+            self.opp_speed[0] = self.obs['linear_vels_x'][1]
+            self.opp_speed[1] = self.obs['linear_vels_y'][1]
+            self.opp_speed[2] = self.obs['ang_vels_z'][1]
 
-        self.ego_pose[0] = self.obs["poses_x"][0]
-        self.ego_pose[1] = self.obs["poses_y"][0]
-        self.ego_pose[2] = self.obs["poses_theta"][0]
-        self.ego_speed[0] = self.obs["linear_vels_x"][0]
-        self.ego_speed[1] = self.obs["linear_vels_y"][0]
-        self.ego_speed[2] = self.obs["ang_vels_z"][0]
+        self.ego_pose[0] = self.obs['poses_x'][0]
+        self.ego_pose[1] = self.obs['poses_y'][0]
+        self.ego_pose[2] = self.obs['poses_theta'][0]
+        self.ego_speed[0] = self.obs['linear_vels_x'][0]
+        self.ego_speed[1] = self.obs['linear_vels_y'][0]
+        self.ego_speed[2] = self.obs['ang_vels_z'][0]
+
+        
 
     def _publish_odom(self, ts):
         ego_odom = Odometry()
         ego_odom.header.stamp = ts
-        ego_odom.header.frame_id = "map"
-        ego_odom.child_frame_id = self.ego_namespace + "/base_link"
-        ego_odom.pose.pose.position.x = self.ego_pose[0] - self.scan_distance_to_base_link * np.cos(self.ego_pose[2])
+        ego_odom.header.frame_id = 'map'
+        ego_odom.child_frame_id = self.ego_namespace + '/base_link'
+        ego_odom.pose.pose.position.x = self.ego_pose[0]
         ego_odom.pose.pose.position.y = self.ego_pose[1]
-        ego_quat = euler.euler2quat(0.0, 0.0, self.ego_pose[2], axes="sxyz")
+        ego_quat = euler.euler2quat(0., 0., self.ego_pose[2], axes='sxyz')
         ego_odom.pose.pose.orientation.x = ego_quat[1]
         ego_odom.pose.pose.orientation.y = ego_quat[2]
         ego_odom.pose.pose.orientation.z = ego_quat[3]
@@ -277,11 +303,11 @@ class GymBridge(Node):
         if self.has_opp:
             opp_odom = Odometry()
             opp_odom.header.stamp = ts
-            opp_odom.header.frame_id = "map"
-            opp_odom.child_frame_id = self.opp_namespace + "/base_link"
+            opp_odom.header.frame_id = 'map'
+            opp_odom.child_frame_id = self.opp_namespace + '/base_link'
             opp_odom.pose.pose.position.x = self.opp_pose[0]
             opp_odom.pose.pose.position.y = self.opp_pose[1]
-            opp_quat = euler.euler2quat(0.0, 0.0, self.opp_pose[2], axes="sxyz")
+            opp_quat = euler.euler2quat(0., 0., self.opp_pose[2], axes='sxyz')
             opp_odom.pose.pose.orientation.x = opp_quat[1]
             opp_odom.pose.pose.orientation.y = opp_quat[2]
             opp_odom.pose.pose.orientation.z = opp_quat[3]
@@ -298,7 +324,7 @@ class GymBridge(Node):
         ego_t.translation.x = self.ego_pose[0]
         ego_t.translation.y = self.ego_pose[1]
         ego_t.translation.z = 0.0
-        ego_quat = euler.euler2quat(0.0, 0.0, self.ego_pose[2], axes="sxyz")
+        ego_quat = euler.euler2quat(0.0, 0.0, self.ego_pose[2], axes='sxyz')
         ego_t.rotation.x = ego_quat[1]
         ego_t.rotation.y = ego_quat[2]
         ego_t.rotation.z = ego_quat[3]
@@ -307,8 +333,8 @@ class GymBridge(Node):
         ego_ts = TransformStamped()
         ego_ts.transform = ego_t
         ego_ts.header.stamp = ts
-        ego_ts.header.frame_id = "map"
-        ego_ts.child_frame_id = self.ego_namespace + "/base_link"
+        ego_ts.header.frame_id = 'map'
+        ego_ts.child_frame_id = self.ego_namespace + '/base_link'
         self.br.sendTransform(ego_ts)
 
         if self.has_opp:
@@ -316,7 +342,7 @@ class GymBridge(Node):
             opp_t.translation.x = self.opp_pose[0]
             opp_t.translation.y = self.opp_pose[1]
             opp_t.translation.z = 0.0
-            opp_quat = euler.euler2quat(0.0, 0.0, self.opp_pose[2], axes="sxyz")
+            opp_quat = euler.euler2quat(0.0, 0.0, self.opp_pose[2], axes='sxyz')
             opp_t.rotation.x = opp_quat[1]
             opp_t.rotation.y = opp_quat[2]
             opp_t.rotation.z = opp_quat[3]
@@ -325,65 +351,63 @@ class GymBridge(Node):
             opp_ts = TransformStamped()
             opp_ts.transform = opp_t
             opp_ts.header.stamp = ts
-            opp_ts.header.frame_id = "map"
-            opp_ts.child_frame_id = self.opp_namespace + "/base_link"
+            opp_ts.header.frame_id = 'map'
+            opp_ts.child_frame_id = self.opp_namespace + '/base_link'
             self.br.sendTransform(opp_ts)
 
     def _publish_wheel_transforms(self, ts):
         ego_wheel_ts = TransformStamped()
-        ego_wheel_quat = euler.euler2quat(0.0, 0.0, self.ego_steer, axes="sxyz")
+        ego_wheel_quat = euler.euler2quat(0., 0., self.ego_steer, axes='sxyz')
         ego_wheel_ts.transform.rotation.x = ego_wheel_quat[1]
         ego_wheel_ts.transform.rotation.y = ego_wheel_quat[2]
         ego_wheel_ts.transform.rotation.z = ego_wheel_quat[3]
         ego_wheel_ts.transform.rotation.w = ego_wheel_quat[0]
         ego_wheel_ts.header.stamp = ts
-        ego_wheel_ts.header.frame_id = self.ego_namespace + "/front_left_hinge"
-        ego_wheel_ts.child_frame_id = self.ego_namespace + "/front_left_wheel"
+        ego_wheel_ts.header.frame_id = self.ego_namespace + '/front_left_hinge'
+        ego_wheel_ts.child_frame_id = self.ego_namespace + '/front_left_wheel'
         self.br.sendTransform(ego_wheel_ts)
-        ego_wheel_ts.header.frame_id = self.ego_namespace + "/front_right_hinge"
-        ego_wheel_ts.child_frame_id = self.ego_namespace + "/front_right_wheel"
+        ego_wheel_ts.header.frame_id = self.ego_namespace + '/front_right_hinge'
+        ego_wheel_ts.child_frame_id = self.ego_namespace + '/front_right_wheel'
         self.br.sendTransform(ego_wheel_ts)
 
         if self.has_opp:
             opp_wheel_ts = TransformStamped()
-            opp_wheel_quat = euler.euler2quat(0.0, 0.0, self.opp_steer, axes="sxyz")
+            opp_wheel_quat = euler.euler2quat(0., 0., self.opp_steer, axes='sxyz')
             opp_wheel_ts.transform.rotation.x = opp_wheel_quat[1]
             opp_wheel_ts.transform.rotation.y = opp_wheel_quat[2]
             opp_wheel_ts.transform.rotation.z = opp_wheel_quat[3]
             opp_wheel_ts.transform.rotation.w = opp_wheel_quat[0]
             opp_wheel_ts.header.stamp = ts
-            opp_wheel_ts.header.frame_id = self.opp_namespace + "/front_left_hinge"
-            opp_wheel_ts.child_frame_id = self.opp_namespace + "/front_left_wheel"
+            opp_wheel_ts.header.frame_id = self.opp_namespace + '/front_left_hinge'
+            opp_wheel_ts.child_frame_id = self.opp_namespace + '/front_left_wheel'
             self.br.sendTransform(opp_wheel_ts)
-            opp_wheel_ts.header.frame_id = self.opp_namespace + "/front_right_hinge"
-            opp_wheel_ts.child_frame_id = self.opp_namespace + "/front_right_wheel"
+            opp_wheel_ts.header.frame_id = self.opp_namespace + '/front_right_hinge'
+            opp_wheel_ts.child_frame_id = self.opp_namespace + '/front_right_wheel'
             self.br.sendTransform(opp_wheel_ts)
 
     def _publish_laser_transforms(self, ts):
         ego_scan_ts = TransformStamped()
         ego_scan_ts.transform.translation.x = self.scan_distance_to_base_link
         # ego_scan_ts.transform.translation.z = 0.04+0.1+0.025
-        ego_scan_ts.transform.rotation.w = 1.0
+        ego_scan_ts.transform.rotation.w = 1.
         ego_scan_ts.header.stamp = ts
-        ego_scan_ts.header.frame_id = self.ego_namespace + "/base_link"
-        ego_scan_ts.child_frame_id = self.ego_namespace + "/laser"
+        ego_scan_ts.header.frame_id = self.ego_namespace + '/base_link'
+        ego_scan_ts.child_frame_id = self.ego_namespace + '/laser'
         self.br.sendTransform(ego_scan_ts)
 
         if self.has_opp:
             opp_scan_ts = TransformStamped()
             opp_scan_ts.transform.translation.x = self.scan_distance_to_base_link
-            opp_scan_ts.transform.rotation.w = 1.0
+            opp_scan_ts.transform.rotation.w = 1.
             opp_scan_ts.header.stamp = ts
-            opp_scan_ts.header.frame_id = self.opp_namespace + "/base_link"
-            opp_scan_ts.child_frame_id = self.opp_namespace + "/laser"
+            opp_scan_ts.header.frame_id = self.opp_namespace + '/base_link'
+            opp_scan_ts.child_frame_id = self.opp_namespace + '/laser'
             self.br.sendTransform(opp_scan_ts)
-
 
 def main(args=None):
     rclpy.init(args=args)
     gym_bridge = GymBridge()
     rclpy.spin(gym_bridge)
 
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/f1tenth_gym_ros/gym_bridge.py
+++ b/f1tenth_gym_ros/gym_bridge.py
@@ -38,91 +38,89 @@ import gym
 import numpy as np
 from transforms3d import euler
 
+
 class GymBridge(Node):
     def __init__(self):
-        super().__init__('gym_bridge')
+        super().__init__("gym_bridge")
 
-        self.declare_parameter('ego_namespace')
-        self.declare_parameter('ego_odom_topic')
-        self.declare_parameter('ego_opp_odom_topic')
-        self.declare_parameter('ego_scan_topic')
-        self.declare_parameter('ego_drive_topic')
-        self.declare_parameter('opp_namespace')
-        self.declare_parameter('opp_odom_topic')
-        self.declare_parameter('opp_ego_odom_topic')
-        self.declare_parameter('opp_scan_topic')
-        self.declare_parameter('opp_drive_topic')
-        self.declare_parameter('scan_distance_to_base_link')
-        self.declare_parameter('scan_fov')
-        self.declare_parameter('scan_beams')
-        self.declare_parameter('map_path')
-        self.declare_parameter('map_img_ext')
-        self.declare_parameter('num_agent')
-        self.declare_parameter('sx')
-        self.declare_parameter('sy')
-        self.declare_parameter('stheta')
-        self.declare_parameter('sx1')
-        self.declare_parameter('sy1')
-        self.declare_parameter('stheta1')
-        self.declare_parameter('kb_teleop')
+        self.declare_parameter("ego_namespace")
+        self.declare_parameter("ego_odom_topic")
+        self.declare_parameter("ego_opp_odom_topic")
+        self.declare_parameter("ego_scan_topic")
+        self.declare_parameter("ego_drive_topic")
+        self.declare_parameter("opp_namespace")
+        self.declare_parameter("opp_odom_topic")
+        self.declare_parameter("opp_ego_odom_topic")
+        self.declare_parameter("opp_scan_topic")
+        self.declare_parameter("opp_drive_topic")
+        self.declare_parameter("scan_distance_to_base_link")
+        self.declare_parameter("scan_fov")
+        self.declare_parameter("scan_beams")
+        self.declare_parameter("map_path")
+        self.declare_parameter("map_img_ext")
+        self.declare_parameter("num_agent")
+        self.declare_parameter("sx")
+        self.declare_parameter("sy")
+        self.declare_parameter("stheta")
+        self.declare_parameter("sx1")
+        self.declare_parameter("sy1")
+        self.declare_parameter("stheta1")
+        self.declare_parameter("kb_teleop")
 
         # check num_agents
-        num_agents = self.get_parameter('num_agent').value
+        num_agents = self.get_parameter("num_agent").value
         if num_agents < 1 or num_agents > 2:
-            raise ValueError('num_agents should be either 1 or 2.')
+            raise ValueError("num_agents should be either 1 or 2.")
         elif type(num_agents) != int:
-            raise ValueError('num_agents should be an int.')
+            raise ValueError("num_agents should be an int.")
 
         # env backend
-        self.env = gym.make('f110_gym:f110-v0',
-                            map=self.get_parameter('map_path').value,
-                            map_ext=self.get_parameter('map_img_ext').value,
-                            num_agents=num_agents)
+        self.env = gym.make("f110_gym:f110-v0", map=self.get_parameter("map_path").value, map_ext=self.get_parameter("map_img_ext").value, num_agents=num_agents, lidar_dist=self.get_parameter("scan_distance_to_base_link").value)
 
-        sx = self.get_parameter('sx').value
-        sy = self.get_parameter('sy').value
-        stheta = self.get_parameter('stheta').value
+        sx = self.get_parameter("sx").value
+        sy = self.get_parameter("sy").value
+        stheta = self.get_parameter("stheta").value
         self.ego_pose = [sx, sy, stheta]
         self.ego_speed = [0.0, 0.0, 0.0]
         self.ego_requested_speed = 0.0
         self.ego_steer = 0.0
         self.ego_collision = False
-        ego_scan_topic = self.get_parameter('ego_scan_topic').value
-        ego_drive_topic = self.get_parameter('ego_drive_topic').value
-        scan_fov = self.get_parameter('scan_fov').value
-        scan_beams = self.get_parameter('scan_beams').value
-        self.angle_min = -scan_fov / 2.
-        self.angle_max = scan_fov / 2.
+        ego_scan_topic = self.get_parameter("ego_scan_topic").value
+        ego_drive_topic = self.get_parameter("ego_drive_topic").value
+        scan_fov = self.get_parameter("scan_fov").value
+        scan_beams = self.get_parameter("scan_beams").value
+        self.angle_min = -scan_fov / 2.0
+        self.angle_max = scan_fov / 2.0
         self.angle_inc = scan_fov / scan_beams
-        self.ego_namespace = self.get_parameter('ego_namespace').value
-        ego_odom_topic = self.ego_namespace + '/' + self.get_parameter('ego_odom_topic').value
-        self.scan_distance_to_base_link = self.get_parameter('scan_distance_to_base_link').value
-        
+        self.ego_namespace = self.get_parameter("ego_namespace").value
+        ego_odom_topic = self.ego_namespace + "/" + self.get_parameter("ego_odom_topic").value
+        self.scan_distance_to_base_link = self.get_parameter("scan_distance_to_base_link").value
+
         if num_agents == 2:
             self.has_opp = True
-            self.opp_namespace = self.get_parameter('opp_namespace').value
-            sx1 = self.get_parameter('sx1').value
-            sy1 = self.get_parameter('sy1').value
-            stheta1 = self.get_parameter('stheta1').value
+            self.opp_namespace = self.get_parameter("opp_namespace").value
+            sx1 = self.get_parameter("sx1").value
+            sy1 = self.get_parameter("sy1").value
+            stheta1 = self.get_parameter("stheta1").value
             self.opp_pose = [sx1, sy1, stheta1]
             self.opp_speed = [0.0, 0.0, 0.0]
             self.opp_requested_speed = 0.0
             self.opp_steer = 0.0
             self.opp_collision = False
-            self.obs, _ , self.done, _ = self.env.reset(np.array([[sx, sy, stheta], [sx1, sy1, stheta1]]))
-            self.ego_scan = list(self.obs['scans'][0])
-            self.opp_scan = list(self.obs['scans'][1])
+            self.obs, _, self.done, _ = self.env.reset(np.array([[sx, sy, stheta], [sx1, sy1, stheta1]]))
+            self.ego_scan = list(self.obs["scans"][0])
+            self.opp_scan = list(self.obs["scans"][1])
 
-            opp_scan_topic = self.get_parameter('opp_scan_topic').value
-            opp_odom_topic = self.opp_namespace + '/' + self.get_parameter('opp_odom_topic').value
-            opp_drive_topic = self.get_parameter('opp_drive_topic').value
+            opp_scan_topic = self.get_parameter("opp_scan_topic").value
+            opp_odom_topic = self.opp_namespace + "/" + self.get_parameter("opp_odom_topic").value
+            opp_drive_topic = self.get_parameter("opp_drive_topic").value
 
-            ego_opp_odom_topic = self.ego_namespace + '/' + self.get_parameter('ego_opp_odom_topic').value
-            opp_ego_odom_topic = self.opp_namespace + '/' + self.get_parameter('opp_ego_odom_topic').value
+            ego_opp_odom_topic = self.ego_namespace + "/" + self.get_parameter("ego_opp_odom_topic").value
+            opp_ego_odom_topic = self.opp_namespace + "/" + self.get_parameter("opp_ego_odom_topic").value
         else:
             self.has_opp = False
-            self.obs, _ , self.done, _ = self.env.reset(np.array([[sx, sy, stheta]]))
-            self.ego_scan = list(self.obs['scans'][0])
+            self.obs, _, self.done, _ = self.env.reset(np.array([[sx, sy, stheta]]))
+            self.ego_scan = list(self.obs["scans"][0])
 
         # sim physical step timer
         self.drive_timer = self.create_timer(0.01, self.drive_timer_callback)
@@ -144,35 +142,14 @@ class GymBridge(Node):
             self.opp_drive_published = False
 
         # subscribers
-        self.ego_drive_sub = self.create_subscription(
-            AckermannDriveStamped,
-            ego_drive_topic,
-            self.drive_callback,
-            10)
-        self.ego_reset_sub = self.create_subscription(
-            PoseWithCovarianceStamped,
-            '/initialpose',
-            self.ego_reset_callback,
-            10)
+        self.ego_drive_sub = self.create_subscription(AckermannDriveStamped, ego_drive_topic, self.drive_callback, 10)
+        self.ego_reset_sub = self.create_subscription(PoseWithCovarianceStamped, "/initialpose", self.ego_reset_callback, 10)
         if num_agents == 2:
-            self.opp_drive_sub = self.create_subscription(
-                AckermannDriveStamped,
-                opp_drive_topic,
-                self.opp_drive_callback,
-                10)
-            self.opp_reset_sub = self.create_subscription(
-                PoseStamped,
-                '/goal_pose',
-                self.opp_reset_callback,
-                10)
+            self.opp_drive_sub = self.create_subscription(AckermannDriveStamped, opp_drive_topic, self.opp_drive_callback, 10)
+            self.opp_reset_sub = self.create_subscription(PoseStamped, "/goal_pose", self.opp_reset_callback, 10)
 
-        if self.get_parameter('kb_teleop').value:
-            self.teleop_sub = self.create_subscription(
-                Twist,
-                '/cmd_vel',
-                self.teleop_callback,
-                10)
-
+        if self.get_parameter("kb_teleop").value:
+            self.teleop_sub = self.create_subscription(Twist, "/cmd_vel", self.teleop_callback, 10)
 
     def drive_callback(self, drive_msg):
         self.ego_requested_speed = drive_msg.drive.speed
@@ -191,12 +168,12 @@ class GymBridge(Node):
         rqy = pose_msg.pose.pose.orientation.y
         rqz = pose_msg.pose.pose.orientation.z
         rqw = pose_msg.pose.pose.orientation.w
-        _, _, rtheta = euler.quat2euler([rqw, rqx, rqy, rqz], axes='sxyz')
+        _, _, rtheta = euler.quat2euler([rqw, rqx, rqy, rqz], axes="sxyz")
         if self.has_opp:
-            opp_pose = [self.obs['poses_x'][1], self.obs['poses_y'][1], self.obs['poses_theta'][1]]
-            self.obs, _ , self.done, _ = self.env.reset(np.array([[rx, ry, rtheta], opp_pose]))
+            opp_pose = [self.obs["poses_x"][1], self.obs["poses_y"][1], self.obs["poses_theta"][1]]
+            self.obs, _, self.done, _ = self.env.reset(np.array([[rx, ry, rtheta], opp_pose]))
         else:
-            self.obs, _ , self.done, _ = self.env.reset(np.array([[rx, ry, rtheta]]))
+            self.obs, _, self.done, _ = self.env.reset(np.array([[rx, ry, rtheta]]))
 
     def opp_reset_callback(self, pose_msg):
         if self.has_opp:
@@ -206,8 +183,9 @@ class GymBridge(Node):
             rqy = pose_msg.pose.orientation.y
             rqz = pose_msg.pose.orientation.z
             rqw = pose_msg.pose.orientation.w
-            _, _, rtheta = euler.quat2euler([rqw, rqx, rqy, rqz], axes='sxyz')
-            self.obs, _ , self.done, _ = self.env.reset(np.array([list(self.ego_pose), [rx, ry, rtheta]]))
+            _, _, rtheta = euler.quat2euler([rqw, rqx, rqy, rqz], axes="sxyz")
+            self.obs, _, self.done, _ = self.env.reset(np.array([list(self.ego_pose), [rx, ry, rtheta]]))
+
     def teleop_callback(self, twist_msg):
         if not self.ego_drive_published:
             self.ego_drive_published = True
@@ -234,24 +212,24 @@ class GymBridge(Node):
         # pub scans
         scan = LaserScan()
         scan.header.stamp = ts
-        scan.header.frame_id = self.ego_namespace + '/laser'
+        scan.header.frame_id = self.ego_namespace + "/laser"
         scan.angle_min = self.angle_min
         scan.angle_max = self.angle_max
         scan.angle_increment = self.angle_inc
-        scan.range_min = 0.
-        scan.range_max = 30.
+        scan.range_min = 0.0
+        scan.range_max = 30.0
         scan.ranges = self.ego_scan
         self.ego_scan_pub.publish(scan)
 
         if self.has_opp:
             opp_scan = LaserScan()
             opp_scan.header.stamp = ts
-            opp_scan.header.frame_id = self.opp_namespace + '/laser'
+            opp_scan.header.frame_id = self.opp_namespace + "/laser"
             opp_scan.angle_min = self.angle_min
             opp_scan.angle_max = self.angle_max
             opp_scan.angle_increment = self.angle_inc
-            opp_scan.range_min = 0.
-            opp_scan.range_max = 30.
+            opp_scan.range_min = 0.0
+            opp_scan.range_max = 30.0
             opp_scan.ranges = self.opp_scan
             self.opp_scan_pub.publish(opp_scan)
 
@@ -262,33 +240,31 @@ class GymBridge(Node):
         self._publish_wheel_transforms(ts)
 
     def _update_sim_state(self):
-        self.ego_scan = list(self.obs['scans'][0])
+        self.ego_scan = list(self.obs["scans"][0])
         if self.has_opp:
-            self.opp_scan = list(self.obs['scans'][1])
-            self.opp_pose[0] = self.obs['poses_x'][1]
-            self.opp_pose[1] = self.obs['poses_y'][1]
-            self.opp_pose[2] = self.obs['poses_theta'][1]
-            self.opp_speed[0] = self.obs['linear_vels_x'][1]
-            self.opp_speed[1] = self.obs['linear_vels_y'][1]
-            self.opp_speed[2] = self.obs['ang_vels_z'][1]
+            self.opp_scan = list(self.obs["scans"][1])
+            self.opp_pose[0] = self.obs["poses_x"][1]
+            self.opp_pose[1] = self.obs["poses_y"][1]
+            self.opp_pose[2] = self.obs["poses_theta"][1]
+            self.opp_speed[0] = self.obs["linear_vels_x"][1]
+            self.opp_speed[1] = self.obs["linear_vels_y"][1]
+            self.opp_speed[2] = self.obs["ang_vels_z"][1]
 
-        self.ego_pose[0] = self.obs['poses_x'][0]
-        self.ego_pose[1] = self.obs['poses_y'][0]
-        self.ego_pose[2] = self.obs['poses_theta'][0]
-        self.ego_speed[0] = self.obs['linear_vels_x'][0]
-        self.ego_speed[1] = self.obs['linear_vels_y'][0]
-        self.ego_speed[2] = self.obs['ang_vels_z'][0]
-
-        
+        self.ego_pose[0] = self.obs["poses_x"][0]
+        self.ego_pose[1] = self.obs["poses_y"][0]
+        self.ego_pose[2] = self.obs["poses_theta"][0]
+        self.ego_speed[0] = self.obs["linear_vels_x"][0]
+        self.ego_speed[1] = self.obs["linear_vels_y"][0]
+        self.ego_speed[2] = self.obs["ang_vels_z"][0]
 
     def _publish_odom(self, ts):
         ego_odom = Odometry()
         ego_odom.header.stamp = ts
-        ego_odom.header.frame_id = 'map'
-        ego_odom.child_frame_id = self.ego_namespace + '/base_link'
-        ego_odom.pose.pose.position.x = self.ego_pose[0]
+        ego_odom.header.frame_id = "map"
+        ego_odom.child_frame_id = self.ego_namespace + "/base_link"
+        ego_odom.pose.pose.position.x = self.ego_pose[0] - self.scan_distance_to_base_link * np.cos(self.ego_pose[2])
         ego_odom.pose.pose.position.y = self.ego_pose[1]
-        ego_quat = euler.euler2quat(0., 0., self.ego_pose[2], axes='sxyz')
+        ego_quat = euler.euler2quat(0.0, 0.0, self.ego_pose[2], axes="sxyz")
         ego_odom.pose.pose.orientation.x = ego_quat[1]
         ego_odom.pose.pose.orientation.y = ego_quat[2]
         ego_odom.pose.pose.orientation.z = ego_quat[3]
@@ -301,11 +277,11 @@ class GymBridge(Node):
         if self.has_opp:
             opp_odom = Odometry()
             opp_odom.header.stamp = ts
-            opp_odom.header.frame_id = 'map'
-            opp_odom.child_frame_id = self.opp_namespace + '/base_link'
+            opp_odom.header.frame_id = "map"
+            opp_odom.child_frame_id = self.opp_namespace + "/base_link"
             opp_odom.pose.pose.position.x = self.opp_pose[0]
             opp_odom.pose.pose.position.y = self.opp_pose[1]
-            opp_quat = euler.euler2quat(0., 0., self.opp_pose[2], axes='sxyz')
+            opp_quat = euler.euler2quat(0.0, 0.0, self.opp_pose[2], axes="sxyz")
             opp_odom.pose.pose.orientation.x = opp_quat[1]
             opp_odom.pose.pose.orientation.y = opp_quat[2]
             opp_odom.pose.pose.orientation.z = opp_quat[3]
@@ -322,7 +298,7 @@ class GymBridge(Node):
         ego_t.translation.x = self.ego_pose[0]
         ego_t.translation.y = self.ego_pose[1]
         ego_t.translation.z = 0.0
-        ego_quat = euler.euler2quat(0.0, 0.0, self.ego_pose[2], axes='sxyz')
+        ego_quat = euler.euler2quat(0.0, 0.0, self.ego_pose[2], axes="sxyz")
         ego_t.rotation.x = ego_quat[1]
         ego_t.rotation.y = ego_quat[2]
         ego_t.rotation.z = ego_quat[3]
@@ -331,8 +307,8 @@ class GymBridge(Node):
         ego_ts = TransformStamped()
         ego_ts.transform = ego_t
         ego_ts.header.stamp = ts
-        ego_ts.header.frame_id = 'map'
-        ego_ts.child_frame_id = self.ego_namespace + '/base_link'
+        ego_ts.header.frame_id = "map"
+        ego_ts.child_frame_id = self.ego_namespace + "/base_link"
         self.br.sendTransform(ego_ts)
 
         if self.has_opp:
@@ -340,7 +316,7 @@ class GymBridge(Node):
             opp_t.translation.x = self.opp_pose[0]
             opp_t.translation.y = self.opp_pose[1]
             opp_t.translation.z = 0.0
-            opp_quat = euler.euler2quat(0.0, 0.0, self.opp_pose[2], axes='sxyz')
+            opp_quat = euler.euler2quat(0.0, 0.0, self.opp_pose[2], axes="sxyz")
             opp_t.rotation.x = opp_quat[1]
             opp_t.rotation.y = opp_quat[2]
             opp_t.rotation.z = opp_quat[3]
@@ -349,63 +325,65 @@ class GymBridge(Node):
             opp_ts = TransformStamped()
             opp_ts.transform = opp_t
             opp_ts.header.stamp = ts
-            opp_ts.header.frame_id = 'map'
-            opp_ts.child_frame_id = self.opp_namespace + '/base_link'
+            opp_ts.header.frame_id = "map"
+            opp_ts.child_frame_id = self.opp_namespace + "/base_link"
             self.br.sendTransform(opp_ts)
 
     def _publish_wheel_transforms(self, ts):
         ego_wheel_ts = TransformStamped()
-        ego_wheel_quat = euler.euler2quat(0., 0., self.ego_steer, axes='sxyz')
+        ego_wheel_quat = euler.euler2quat(0.0, 0.0, self.ego_steer, axes="sxyz")
         ego_wheel_ts.transform.rotation.x = ego_wheel_quat[1]
         ego_wheel_ts.transform.rotation.y = ego_wheel_quat[2]
         ego_wheel_ts.transform.rotation.z = ego_wheel_quat[3]
         ego_wheel_ts.transform.rotation.w = ego_wheel_quat[0]
         ego_wheel_ts.header.stamp = ts
-        ego_wheel_ts.header.frame_id = self.ego_namespace + '/front_left_hinge'
-        ego_wheel_ts.child_frame_id = self.ego_namespace + '/front_left_wheel'
+        ego_wheel_ts.header.frame_id = self.ego_namespace + "/front_left_hinge"
+        ego_wheel_ts.child_frame_id = self.ego_namespace + "/front_left_wheel"
         self.br.sendTransform(ego_wheel_ts)
-        ego_wheel_ts.header.frame_id = self.ego_namespace + '/front_right_hinge'
-        ego_wheel_ts.child_frame_id = self.ego_namespace + '/front_right_wheel'
+        ego_wheel_ts.header.frame_id = self.ego_namespace + "/front_right_hinge"
+        ego_wheel_ts.child_frame_id = self.ego_namespace + "/front_right_wheel"
         self.br.sendTransform(ego_wheel_ts)
 
         if self.has_opp:
             opp_wheel_ts = TransformStamped()
-            opp_wheel_quat = euler.euler2quat(0., 0., self.opp_steer, axes='sxyz')
+            opp_wheel_quat = euler.euler2quat(0.0, 0.0, self.opp_steer, axes="sxyz")
             opp_wheel_ts.transform.rotation.x = opp_wheel_quat[1]
             opp_wheel_ts.transform.rotation.y = opp_wheel_quat[2]
             opp_wheel_ts.transform.rotation.z = opp_wheel_quat[3]
             opp_wheel_ts.transform.rotation.w = opp_wheel_quat[0]
             opp_wheel_ts.header.stamp = ts
-            opp_wheel_ts.header.frame_id = self.opp_namespace + '/front_left_hinge'
-            opp_wheel_ts.child_frame_id = self.opp_namespace + '/front_left_wheel'
+            opp_wheel_ts.header.frame_id = self.opp_namespace + "/front_left_hinge"
+            opp_wheel_ts.child_frame_id = self.opp_namespace + "/front_left_wheel"
             self.br.sendTransform(opp_wheel_ts)
-            opp_wheel_ts.header.frame_id = self.opp_namespace + '/front_right_hinge'
-            opp_wheel_ts.child_frame_id = self.opp_namespace + '/front_right_wheel'
+            opp_wheel_ts.header.frame_id = self.opp_namespace + "/front_right_hinge"
+            opp_wheel_ts.child_frame_id = self.opp_namespace + "/front_right_wheel"
             self.br.sendTransform(opp_wheel_ts)
 
     def _publish_laser_transforms(self, ts):
         ego_scan_ts = TransformStamped()
         ego_scan_ts.transform.translation.x = self.scan_distance_to_base_link
         # ego_scan_ts.transform.translation.z = 0.04+0.1+0.025
-        ego_scan_ts.transform.rotation.w = 1.
+        ego_scan_ts.transform.rotation.w = 1.0
         ego_scan_ts.header.stamp = ts
-        ego_scan_ts.header.frame_id = self.ego_namespace + '/base_link'
-        ego_scan_ts.child_frame_id = self.ego_namespace + '/laser'
+        ego_scan_ts.header.frame_id = self.ego_namespace + "/base_link"
+        ego_scan_ts.child_frame_id = self.ego_namespace + "/laser"
         self.br.sendTransform(ego_scan_ts)
 
         if self.has_opp:
             opp_scan_ts = TransformStamped()
             opp_scan_ts.transform.translation.x = self.scan_distance_to_base_link
-            opp_scan_ts.transform.rotation.w = 1.
+            opp_scan_ts.transform.rotation.w = 1.0
             opp_scan_ts.header.stamp = ts
-            opp_scan_ts.header.frame_id = self.opp_namespace + '/base_link'
-            opp_scan_ts.child_frame_id = self.opp_namespace + '/laser'
+            opp_scan_ts.header.frame_id = self.opp_namespace + "/base_link"
+            opp_scan_ts.child_frame_id = self.opp_namespace + "/laser"
             self.br.sendTransform(opp_scan_ts)
+
 
 def main(args=None):
     rclpy.init(args=args)
     gym_bridge = GymBridge()
     rclpy.spin(gym_bridge)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
There is an error in the simulator that the LiDAR scan beams are not shooting from the front of car. Instead, it is from behind. This is because the code in f1tenth_gym (not in f1tenth_gym_ros) assumes that the LiDAR frame is same as the car frame. 

To fix this issue in f1tenth_gym, I separate the two frames by shifting the pose of LiDAR by a distance named "lidar_dist". This variable is accessible from bridge node in f1tenth_gym_ros now. There, in this updated f1tenth_gym_ros repo, I link the scan_distance_to_base_link to new variable lidar_dist in f1tenth_gym environment. 

Please review this with the updated f1tenth_gym repo: https://github.com/Carperis/f1tenth_gym/tree/sam_fix_lidar_pos

The following is a brief comparison:
![iShot_2025-03-22_05 17 15-2](https://github.com/user-attachments/assets/7282ab72-b372-423e-b67e-2620ff6ae18c)