### PR TITLE
The Lidar frame position mismatch in simulation problem has been solved

### DIFF
--- a/config/sim.yaml
+++ b/config/sim.yaml
@@ -35,14 +35,14 @@ bridge:
     opp_drive_topic: 'opp_drive'
 
     # transform related
-    scan_distance_to_base_link: 0.0
+    scan_distance_to_base_link: 0.275
     
     # laserscan parameters
     scan_fov: 4.7
     scan_beams: 1080
 
     # map parameters
-    map_path: 'levine'
+    map_path: '/home/kaitianchao/sim_ws/src/f1tenth_gym_ros/maps/levine_obs_custom'
     map_img_ext: '.png'
 
     # car parameters and scale


### PR DESCRIPTION
Hi, my name is **Kaitian Chao**, a student in ESE 6150 F1tenth autonomous racing cars. **This is a PR of the fix to the Lidar frame position mismatch in simulation. I hope to get extra credit for this as promised by TA.** 

(This fix was done a month ago and could also be seen at the Ed post: 
https://edstem.org/us/courses/73863/discussion/6232801)

According to our car model and the .xacro file of the car ("sim_ws/src/f1tenth_gym_ros/launch/ego_racecar.xacro"), our lidar should be at the front of the car, consistent with our real car. 

But now the Lidar frame is **actually at the back of the car in simulation**, which means, **all the lidar ranges we get in simulation is not actually what we truly observe with the lidar at the front, but at the back (so it is wrong, or at least biased)!** But we have our lidar at the front for the real car instead. So this could largely increase the difficulty of the sim2real process!

### How I found it and verify this bug:


I was implementing the extend_disparity algorithm to avoid the obstacles for lab4. I only kept the lidar ranges with scan angle between (-90 and 90) degree. To debug, I visualized the processed lidar ranges as a seperate topic in Rviz to verify what the lidar actually see. 

But weirdly, even though I set the "field angle" to be (-1.57 rad, 1.57 rad), the processed lidar range still goes behind the lidar position on the car and form an obtuse observe angle:

![image](https://github.com/user-attachments/assets/72225366-ee72-47c0-a49a-e93cbaf43151)




So that means our lidar range perhaps start from the back of the car, instead of the true lidar position on the car model!
To verify this, I visualized both the **laser frame** (our lidar ranges are measured in this frame) and the **laser_model frame** (The actual position of our lidar on the car):

![image](https://github.com/user-attachments/assets/e3baa133-96b1-4c50-b757-d5df103fbaa0)


As shown above, there is indeed **a mismatch between the laser frame position and the true lidar position! Our lidar ranges were actually all measured from the back of our car but not from the true lidar position!**



### Locate the bug in code:

I looked through the gym_bridge.py code in f1tenth_gym_ros package. There is a parameter called: **scan_distance_to_base_link**. After digesting the code, I think this is the parameter that controls the frame offset between the base frame and laser frame along the x axis. 
This parameter is specified through the sim.yaml file at:

`
sim_ws/install/f1tenth_gym_ros/share/f1tenth_gym_ros/config/sim.yaml`


(This is exactly the yaml file we set our map to levine_obs or levine_blocked)

And in the sim.yaml, this parameter was set to 0. So that makes the laser frame align with the base frame along the x axis!

But according to the ego_racecar.xacro file of our car, this parameter should be:

`
<xacro:property name="laser_distance_from_base_link" value="0.275" />`


instead.



### How I solved it:

So I modified this value in the sim.yaml file to:

`scan_distance_to_base_link: 0.275`

![image](https://github.com/user-attachments/assets/8c1def72-8f29-4996-9372-bf9994f8fca9)


And this problem is solved. Now the laser frame (where all lidar ranges are measured) are align with the lidar position along the x axis of the car. So now we are able to measure the lidar range from the actual position at the front of the car but not the back. 

And also you can see that if I set the lidar observe angle to be (-1.57 rad, 1.57 rad), the ranges observed stop exactly at the lidar position (so the lidar won't see things behind it). I've tested other observing angles as well and now they are all correct!



### Not sure about whether the z-offset should also be fixed:

There is still an offset along the z-axis between the lidar position and the lidar frame as you can see. 

![image](https://github.com/user-attachments/assets/dcfd3473-dd5a-4ad0-8658-0f0308fbe979)




This is because the z translation part is somehow commented out in the gym_bridge.py (I don't know why they are commented out, this is what it looks when we cloned it)

So I guess if we also want to fix the z offset, we can uncomment this z translation line. But I am not sure whether the z offset really matters and whether we should do this.

**But at least now the lidar frame is aligned with the actual position of the lidar on the car along the x-axis. So we are indeed observing everything from the front of the car!**







