### PR TITLE
Fix docker exec command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ docker-compose up
 ``` 
 3. In a separate terminal, run the following, and you'll have the a bash session in the simulation container. `tmux` is available for convenience.
 ```bash
-docker exec -it f1tenth_gym_ros-sim-1 /bin/bash
+docker exec -it f1tenth_gym_ros_sim_1 /bin/bash
 ```
 4. In your browser, navigate to [http://localhost:8080/vnc.html](http://localhost:8080/vnc.html), you should see the noVNC logo with the connect button. Click the connect button to connect to the session.
 


### PR DESCRIPTION
fix: correct container name in non-GPU docker exec command

The 'Without an NVIDIA GPU' section of the README used `f1tenth_gym_ros-sim-1` as the container name, but Docker Compose generates it as `f1tenth_gym_ros_sim_1`.

Fixes #41