### PR TITLE
Wheel spin at the true rolling rate, mesh alignment fixes, 8-car default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ If Foxglove does not auto-open (for example in headless/container setups), open 
 - Browser: [https://app.foxglove.dev/?ds=foxglove-websocket&ds.url=ws://localhost:8765](https://app.foxglove.dev/?ds=foxglove-websocket&ds.url=ws://localhost:8765)
 - Studio: `foxglove://open?ds=foxglove-websocket&ds.url=ws://localhost:8765`
 
-To visualize the simulation, import the layout file `config/foxglove/gym_bridge_foxglove.json`. It ships with robot descriptions for four cars (the ego plus three opponents), so it covers every agent count the shipped `sim.yaml` can start by default. To visualize more than four agents, add a description for each extra opponent in the 3D panel's settings, subscribing to `/opp_robot_description4`, `/opp_robot_description5`, and so on. Foxglove is the recommended setup, but if you prefer RViz (old Gym setup), use `config/rviz/gym_bridge.rviz`.
+To visualize the simulation, import the layout file `config/foxglove/gym_bridge_foxglove.json`. It ships with robot descriptions for four cars (the ego plus three opponents). The shipped `sim.yaml` carries start poses for up to eight cars, so to visualize agents five through eight, add a description for each extra opponent in the 3D panel's settings, subscribing to `/opp_robot_description4`, `/opp_robot_description5`, and so on. Foxglove is the recommended setup, but if you prefer RViz (old Gym setup), use `config/rviz/gym_bridge.rviz`.
 
 You can then run another node by creating another bash session in `tmux` or a separate terminal.
 
@@ -121,7 +121,7 @@ You can then run another node by creating another bash session in `tmux` or a se
 ```bash
 ros2 launch f1tenth_gym_ros gym_bridge_launch.py num_agent:=4
 ```
-- The ego and opponent starting poses can also be changed via parameters (`sx`/`sy`/`stheta` for the ego, `sx1`/`sy1`/`stheta1` onwards for the opponents), these are in the global map coordinate frame. Every agent you ask for needs a start pose: if `num_agent` is 3 but `sx2`/`sy2`/`stheta2` are missing, the bridge stops and tells you which parameters to add rather than guessing a spot on the map for you. The poses shipped in `sim.yaml` line four cars up along the Levine straight, so `num_agent:=4` works out of the box; add `sx4`/`sy4`/`stheta4` and so on to race more, and change them when you change the map.
+- The ego and opponent starting poses can also be changed via parameters (`sx`/`sy`/`stheta` for the ego, `sx1`/`sy1`/`stheta1` onwards for the opponents), these are in the global map coordinate frame. Every agent you ask for needs a start pose: if `num_agent` is 3 but `sx2`/`sy2`/`stheta2` are missing, the bridge stops and tells you which parameters to add rather than guessing a spot on the map for you. The poses shipped in `sim.yaml` line up eight cars on the Levine map (two rows of four), so anything up to `num_agent:=8` works out of the box; add `sx8`/`sy8`/`stheta8` and so on to race more, and change them when you change the map.
 - A different sim config can be selected at launch time. The value is a file name in `config/`, a package relative path, or an absolute path:
 ```bash
 ros2 launch f1tenth_gym_ros gym_bridge_launch.py config:=my_sim.yaml

--- a/config/rviz/urdf_config.rviz
+++ b/config/rviz/urdf_config.rviz
@@ -1,0 +1,243 @@
+Panels:
+  - Class: rviz_common/Displays
+    Help Height: 141
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /TF1/Frames1
+        - /Camera1
+        - /Camera1/Topic1
+      Splitter Ratio: 0.5
+    Tree Height: 454
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Expanded:
+      - /2D Goal Pose1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz_common/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz_default_plugins/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz_default_plugins/TF
+      Enabled: false
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: false
+      Tree:
+        {}
+      Update Interval: 0
+      Value: false
+    - Alpha: 1
+      Class: rviz_default_plugins/RobotModel
+      Collision Enabled: false
+      Description File: ""
+      Description Source: Topic
+      Description Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /robot_description
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        ego_racecar/back_left_hinge:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        ego_racecar/back_left_wheel:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ego_racecar/back_right_hinge:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        ego_racecar/back_right_wheel:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ego_racecar/base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ego_racecar/front_left_hinge:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        ego_racecar/front_left_wheel:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ego_racecar/front_right_hinge:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        ego_racecar/front_right_wheel:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ego_racecar/laser_model:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+      Mass Properties:
+        Inertia: false
+        Mass: false
+      Name: RobotModel
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Class: rviz_default_plugins/Camera
+      Enabled: true
+      Far Plane Distance: 100
+      Image Rendering: background and overlay
+      Name: Camera
+      Overlay Alpha: 0.5
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /camera/image_raw
+      Value: true
+      Visibility:
+        Grid: true
+        RobotModel: true
+        TF: true
+        Value: false
+      Zoom Factor: 1
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: ego_racecar/base_link
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/Interact
+      Hide Inactive Objects: true
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+    - Class: rviz_default_plugins/SetInitialPose
+      Covariance x: 0.25
+      Covariance y: 0.25
+      Covariance yaw: 0.06853891909122467
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
+    - Class: rviz_default_plugins/PublishPoint
+      Single click: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 0.1358836442232132
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -0.21735188364982605
+        Y: -0.13086390495300293
+        Z: 0.06603789329528809
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.22315292060375214
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 3.162325859069824
+    Saved: ~
+Window Geometry:
+  Camera:
+    collapsed: false
+  Displays:
+    collapsed: false
+  Height: 1016
+  Hide Left Dock: false
+  Hide Right Dock: true
+  QMainWindow State: 000000ff00000000fd0000000400000000000001560000035afc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d00000290000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00430061006d00650072006101000002d3000000c40000002800ffffff000000010000010f000004d9fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003f000004d9000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007800000003efc0100000002fb0000000800540069006d0065010000000000000780000002fb00fffffffb0000000800540069006d00650100000000000004500000000000000000000006240000035a00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: true
+  Width: 1920
+  X: 0
+  Y: 27

--- a/config/sim.yaml
+++ b/config/sim.yaml
@@ -84,6 +84,26 @@ bridge:
     sy3: 0.0
     stheta3: 0.0
 
+    # opp 4 starting pose on map
+    sx4: -12.0
+    sy4: 8.5
+    stheta4: 3.14
+
+    # opp 5 starting pose on map
+    sx5: -5.5
+    sy5: 8.5
+    stheta5: 3.14
+
+    # opp 6 starting pose on map
+    sx6: 1.0
+    sy6: 8.5
+    stheta6: 3.14
+
+    # opp 7 starting pose on map
+    sx7: 8.0
+    sy7: 8.5
+    stheta7: 3.14
+
     # teleop
     kb_teleop: True
 

--- a/f1tenth_gym_ros/gym_bridge.py
+++ b/f1tenth_gym_ros/gym_bridge.py
@@ -73,6 +73,13 @@ def opp_suffix(opp_index):
     return '' if opp_index == 1 else str(opp_index)
 
 
+# Visual wheel spin. Radius matches the wheel meshes in urdf/racecar_mesh.xacro
+# (0.102 m diameter at f1tenth size); the per-platform factors are the same
+# wheelbase ratios that xacro scales the meshes by.
+WHEEL_RADIUS = 0.051
+VEHICLE_MESH_SCALE = {'f1tenth': 1.0, 'f1fifth': 1.656456, 'fullscale': 7.449941}
+
+
 def _resolve_yaml_path(base_path: pathlib.Path) -> pathlib.Path:
     if base_path.suffix in (".yaml", ".yml"):
         return base_path
@@ -155,6 +162,8 @@ class Opponent:
         self.speed = [0.0, 0.0, 0.0]
         self.requested_speed = 0.0
         self.steer = 0.0
+        self.v = 0.0  # signed longitudinal speed, drives the wheel spin
+        self.wheel_angle = 0.0
         self.scan = []
         self.scan_pub = None
         self.odom_pub = None
@@ -235,6 +244,7 @@ class GymBridge(Node):
             self.vehicle_params = get_f1fifth_vehicle_parameters()
         else:
             raise ValueError('vehicle_params should be either f1tenth, fullscale, or f1fifth.')
+        self.wheel_radius = WHEEL_RADIUS * VEHICLE_MESH_SCALE[vehicle_params_key]
 
         scale = self.get_parameter('scale').value
         map_path = self.get_parameter('map_path').value
@@ -296,9 +306,10 @@ class GymBridge(Node):
             LoopCounterMode.FRENET_BASED if has_reference_line else LoopCounterMode.TOGGLE
         )
         compute_frenet = has_reference_line
+        self.sim_timestep = 0.01
         simulation_cfg = SimulationConfig(
-            timestep=0.01,
-            integrator_timestep=0.01,
+            timestep=self.sim_timestep,
+            integrator_timestep=self.sim_timestep,
             integrator=IntegratorType.RK4,
             dynamics_model=DynamicModel.ST,
             loop_counter=loop_counter,
@@ -333,6 +344,8 @@ class GymBridge(Node):
         self.ego_requested_speed = 0.0
         self.ego_steer = 0.0
         self.ego_collision = False
+        self.ego_v = 0.0  # signed longitudinal speed, drives the wheel spin
+        self.ego_wheel_angle = 0.0
         ego_scan_topic = self.get_parameter('ego_scan_topic').value
         ego_drive_topic = self.get_parameter('ego_drive_topic').value
         self.angle_min = self.lidar_cfg.angle_min
@@ -553,6 +566,18 @@ class GymBridge(Node):
         actions += [[opp.steer, opp.requested_speed] for opp in self.opps]
         _, _, self.done, _, _ = self.env.step(np.array(actions))
         self._update_sim_state()
+
+        # Advance the visual wheel spin by the no-slip rolling rate v/r. The ST
+        # dynamics model carries no wheel-speed states, so this is the closest
+        # thing to the actual wheel RPM the sim can provide.
+        two_pi = 2.0 * math.pi
+        self.ego_wheel_angle = (
+            self.ego_wheel_angle + self.ego_v / self.wheel_radius * self.sim_timestep
+        ) % two_pi
+        for opp in self.opps:
+            opp.wheel_angle = (
+                opp.wheel_angle + opp.v / self.wheel_radius * self.sim_timestep
+            ) % two_pi
         if self.get_parameter('use_sim_time_bridge').value:
             clock_msg = Clock()
             sim_time = self.env.unwrapped.sim_time
@@ -608,6 +633,7 @@ class GymBridge(Node):
         self.ego_pose[2] = float(poses[0, 2])
         ego_speed = float(std_state[0, 3])
         ego_beta = float(std_state[0, 6])
+        self.ego_v = ego_speed
         self.ego_speed[0] = float(ego_speed * np.cos(ego_beta))
         self.ego_speed[1] = float(ego_speed * np.sin(ego_beta))
         self.ego_speed[2] = float(std_state[0, 5])
@@ -619,6 +645,7 @@ class GymBridge(Node):
             opp.pose[2] = float(poses[i, 2])
             opp_speed = float(std_state[i, 3])
             opp_beta = float(std_state[i, 6])
+            opp.v = opp_speed
             opp.speed[0] = float(opp_speed * np.cos(opp_beta))
             opp.speed[1] = float(opp_speed * np.sin(opp_beta))
             opp.speed[2] = float(std_state[i, 5])
@@ -672,22 +699,28 @@ class GymBridge(Node):
             self.br.sendTransform(ts_msg)
 
     def _publish_wheel_transforms(self, ts):
-        for namespace, steer in [(self.ego_namespace, self.ego_steer)] + [
-            (opp.namespace, opp.steer) for opp in self.opps
-        ]:
+        for namespace, steer, spin in [
+            (self.ego_namespace, self.ego_steer, self.ego_wheel_angle)
+        ] + [(opp.namespace, opp.steer, opp.wheel_angle) for opp in self.opps]:
+            # Front wheels steer about z first, then roll about their own
+            # (steered) axle; rear wheels only roll. 'ZY' = intrinsic Rz @ Ry.
+            front_quat = Rotation.from_euler('ZY', [steer, spin]).as_quat()
+            rear_quat = Rotation.from_euler('y', spin).as_quat()
             wheel_ts = TransformStamped()
-            wheel_quat = Rotation.from_euler('xyz', [0., 0., steer]).as_quat()
-            wheel_ts.transform.rotation.x = wheel_quat[0]
-            wheel_ts.transform.rotation.y = wheel_quat[1]
-            wheel_ts.transform.rotation.z = wheel_quat[2]
-            wheel_ts.transform.rotation.w = wheel_quat[3]
             wheel_ts.header.stamp = ts
-            wheel_ts.header.frame_id = namespace + '/front_left_hinge'
-            wheel_ts.child_frame_id = namespace + '/front_left_wheel'
-            self.br.sendTransform(wheel_ts)
-            wheel_ts.header.frame_id = namespace + '/front_right_hinge'
-            wheel_ts.child_frame_id = namespace + '/front_right_wheel'
-            self.br.sendTransform(wheel_ts)
+            for hinge, wheel, quat in (
+                ('front_left_hinge', 'front_left_wheel', front_quat),
+                ('front_right_hinge', 'front_right_wheel', front_quat),
+                ('back_left_hinge', 'back_left_wheel', rear_quat),
+                ('back_right_hinge', 'back_right_wheel', rear_quat),
+            ):
+                wheel_ts.transform.rotation.x = quat[0]
+                wheel_ts.transform.rotation.y = quat[1]
+                wheel_ts.transform.rotation.z = quat[2]
+                wheel_ts.transform.rotation.w = quat[3]
+                wheel_ts.header.frame_id = namespace + '/' + hinge
+                wheel_ts.child_frame_id = namespace + '/' + wheel
+                self.br.sendTransform(wheel_ts)
 
     def _publish_laser_transforms(self, ts):
         scan_quat = Rotation.from_euler('xyz', [0.0, 0.0, self.scan_tf[2]]).as_quat()

--- a/launch/display.launch.xml
+++ b/launch/display.launch.xml
@@ -1,0 +1,29 @@
+<!-- URDF/joint debugging for the roboracer mesh model, no sim involved.
+     robot_state_publisher + joint_state_publisher_gui sliders + RViz, so each
+     wheel joint can be moved by hand to check its axis and mesh alignment.
+
+         ros2 launch f1tenth_gym_ros display.launch.xml
+         ros2 launch f1tenth_gym_ros display.launch.xml car_name:=opp_racecar
+-->
+<launch>
+    <arg name="car_name" default="ego_racecar" />
+    <arg name="vehicle" default="f1tenth" />
+
+    <let name="urdf_path"
+        value="$(find-pkg-share f1tenth_gym_ros)/urdf/racecar_mesh.xacro" />
+
+    <let name="rviz_config_path"
+        value="$(find-pkg-share f1tenth_gym_ros)/config/rviz/urdf_config.rviz" />
+
+    <node pkg="robot_state_publisher" exec="robot_state_publisher">
+        <param name="robot_description"
+            value="$(command 'xacro $(var urdf_path) car_name:=$(var car_name) vehicle:=$(var vehicle)')"
+            type="str" />
+    </node>
+
+    <node pkg="joint_state_publisher_gui" exec="joint_state_publisher_gui" />
+
+    <node pkg="rviz2" exec="rviz2" output="screen"
+          args="-d $(var rviz_config_path)" />
+
+</launch>

--- a/launch/gym_bridge_launch.py
+++ b/launch/gym_bridge_launch.py
@@ -29,6 +29,7 @@ from launch.actions import DeclareLaunchArgument, ExecuteProcess, LogInfo, Opaqu
 from launch.conditions import IfCondition, LaunchConfigurationEquals
 from launch.substitutions import Command, LaunchConfiguration
 from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
 from ament_index_python.packages import get_package_share_directory
 
 # Tints the accent mesh so ego and opponents stay as easy to tell apart as the
@@ -195,12 +196,14 @@ def _launch_setup(context, *args, **kwargs):
         """xacro command line for one car."""
         # Quoted because the accent colour is an rgba string with spaces in it
         # and Command shlex-splits what it is given.
-        return Command([
+        # ParameterValue(value_type=str) stops launch from yaml-parsing the URDF
+        # string, which blows up on any "colon + space" in the xacro output.
+        return ParameterValue(Command([
             'xacro ', os.path.join(urdf_dir, 'racecar_mesh.xacro'),
             ' car_name:=', car_name,
             ' accent_color:="', accent_color, '"',
             ' vehicle:=', vehicle_params,
-        ])
+        ]), value_type=str)
 
     ego_robot_publisher = Node(
         package='robot_state_publisher',

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>nav2_map_server</exec_depend>

--- a/scripts/measure_wheel_alignment.py
+++ b/scripts/measure_wheel_alignment.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Measure how far each wheel glb's axle is from the link y axis.
+
+The exported wheel meshes are tilted slightly off their hub axis. When the gym
+bridge spins the wheel TF about link y, any residual angle between the mesh
+axle and link y shows up as a visible wobble. This script finds the axle from
+the mesh geometry (PCA over the vertices - a wheel is thin along its axle) and
+prints the exact visual-origin rpy that makes the axle coincide with link y.
+
+Paste the printed values into the WHEEL ALIGNMENT block of
+urdf/racecar_mesh.xacro.
+
+Only needs numpy + scipy. Run from the repo root:
+
+    python3 scripts/measure_wheel_alignment.py
+"""
+import json
+import pathlib
+import struct
+import sys
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+MESH_DIR = pathlib.Path(__file__).resolve().parent.parent / 'meshes'
+WHEELS = [
+    'roboracer_wheel_front_left',
+    'roboracer_wheel_front_right',
+    'roboracer_wheel_rear_left',
+    'roboracer_wheel_rear_right',
+]
+
+COMPONENT_DTYPES = {5120: np.int8, 5121: np.uint8, 5122: np.int16,
+                    5123: np.uint16, 5125: np.uint32, 5126: np.float32}
+TYPE_COUNTS = {'SCALAR': 1, 'VEC2': 2, 'VEC3': 3, 'VEC4': 4, 'MAT4': 16}
+
+
+def load_glb(path):
+    data = path.read_bytes()
+    assert data[:4] == b'glTF', f'{path} is not a glb'
+    offset = 12
+    gltf, bin_chunk = None, None
+    while offset < len(data):
+        clen, ctype = struct.unpack_from('<II', data, offset)
+        payload = data[offset + 8:offset + 8 + clen]
+        if ctype == 0x4E4F534A:  # JSON
+            gltf = json.loads(payload)
+        elif ctype == 0x004E4942:  # BIN
+            bin_chunk = payload
+        offset += 8 + clen
+    return gltf, bin_chunk
+
+
+def read_accessor(gltf, bin_chunk, index):
+    acc = gltf['accessors'][index]
+    view = gltf['bufferViews'][acc['bufferView']]
+    dtype = COMPONENT_DTYPES[acc['componentType']]
+    ncomp = TYPE_COUNTS[acc['type']]
+    start = view.get('byteOffset', 0) + acc.get('byteOffset', 0)
+    stride = view.get('byteStride') or ncomp * np.dtype(dtype).itemsize
+    out = np.empty((acc['count'], ncomp), dtype=dtype)
+    itemsize = ncomp * np.dtype(dtype).itemsize
+    for i in range(acc['count']):
+        out[i] = np.frombuffer(bin_chunk, dtype=dtype, count=ncomp,
+                               offset=start + i * stride)
+    return out.astype(np.float64)
+
+
+def node_matrix(node):
+    if 'matrix' in node:
+        return np.array(node['matrix'], dtype=np.float64).reshape(4, 4).T
+    m = np.eye(4)
+    if 'rotation' in node:
+        m[:3, :3] = Rotation.from_quat(node['rotation']).as_matrix()
+    if 'scale' in node:
+        m[:3, :3] = m[:3, :3] @ np.diag(node['scale'])
+    if 'translation' in node:
+        m[:3, 3] = node['translation']
+    return m
+
+
+def collect_vertices(gltf, bin_chunk):
+    """All POSITION vertices with node transforms applied (world = as loaded)."""
+    verts = []
+
+    def visit(node_index, parent):
+        node = gltf['nodes'][node_index]
+        world = parent @ node_matrix(node)
+        if 'mesh' in node:
+            mesh = gltf['meshes'][node['mesh']]
+            for prim in mesh.get('primitives', []):
+                if 'POSITION' in prim.get('attributes', {}):
+                    v = read_accessor(gltf, bin_chunk, prim['attributes']['POSITION'])
+                    vh = np.hstack([v, np.ones((len(v), 1))])
+                    verts.append((world @ vh.T).T[:, :3])
+        for child in node.get('children', []):
+            visit(child, world)
+
+    scene = gltf['scenes'][gltf.get('scene', 0)]
+    for root in scene['nodes']:
+        visit(root, np.eye(4))
+    return np.vstack(verts)
+
+
+def main():
+    print(f'{"wheel":26s} {"tilt":>7s}  correction rpy [deg]  (visual origin, link frame)')
+    for name in WHEELS:
+        gltf, bin_chunk = load_glb(MESH_DIR / f'{name}.glb')
+        verts = collect_vertices(gltf, bin_chunk)
+        center = verts.mean(axis=0)
+        cov = np.cov((verts - center).T)
+        eigvals, eigvecs = np.linalg.eigh(cov)
+        axle = eigvecs[:, 0]  # smallest spread = the axle (wheels are thin)
+        if axle[1] < 0:
+            axle = -axle
+        target = np.array([0.0, 1.0, 0.0])
+        tilt = np.degrees(np.arccos(np.clip(axle @ target, -1, 1)))
+        axis = np.cross(axle, target)
+        norm = np.linalg.norm(axis)
+        if norm < 1e-12:
+            rpy = np.zeros(3)
+        else:
+            rot = Rotation.from_rotvec(axis / norm * np.radians(tilt))
+            rpy = rot.as_euler('xyz', degrees=True)  # URDF rpy convention
+        print(f'{name:26s} {tilt:6.2f}°  '
+              f'rpy = [{rpy[0]:+7.3f}, {rpy[1]:+7.3f}, {rpy[2]:+7.3f}]  '
+              f'center offset = [{center[0]:+.4f}, {center[1]:+.4f}, {center[2]:+.4f}]')
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
-        (os.path.join('share', package_name, 'launch'), glob('launch/*.py')),
+        (os.path.join('share', package_name, 'launch'), glob('launch/*.py') + glob('launch/*.xml')),
         (os.path.join('share', package_name, 'launch', 'slam'), glob('launch/slam/*.yaml')),
         (os.path.join('share', package_name, 'urdf'), glob('urdf/*.xacro')),
         # foxglove_bridge and RViz resolve the URDF's package:// mesh URIs out of

--- a/urdf/racecar_mesh.xacro
+++ b/urdf/racecar_mesh.xacro
@@ -5,6 +5,11 @@
 
   Written by scripts/usd_to_mesh.py from meshes/roboracer.usd. Re-run that script
   after changing the USD; hand edits here are lost on the next regeneration.
+  NOTE - the wheel-spin structure below (back_*_hinge links + continuous wheel
+  joints, animated by the gym bridge) is a hand edit that must be folded into
+  usd_to_mesh.py before the next regeneration. Avoid "colon + space" anywhere
+  in this file; unless robot_description is wrapped in ParameterValue, launch
+  yaml-parses the URDF string and a colon turns it into a mapping.
 
   Same link and joint names as urdf/ego_racecar.xacro so TF, the gym bridge and
   anything downstream keep working - only the geometry changed, from primitive
@@ -36,6 +41,25 @@
     <xacro:property name="lr" value="${1.508760}"/>
   </xacro:if>
   <xacro:property name="mesh_dir" value="package://f1tenth_gym_ros/meshes"/>
+
+  <!-- ============================ WHEEL ALIGNMENT ============================
+       Per-wheel visual rpy corrections [deg]. All four wheels are baked from the
+       same source model but at their posed orientation in the USD scene, so each
+       glb carries a slightly different camber+toe tilt off its true axle. Any
+       residual angle between the mesh axle and link y wobbles once the bridge
+       spins the wheel TF, so the corrections must be exact per wheel - these are
+       measured from the mesh geometry by scripts/measure_wheel_alignment.py
+       (rerun it and paste new values after re-exporting the meshes). -->
+  <xacro:property name="align_fl_deg" value="${[-3.574, 0.068, 2.177]}"/>
+  <xacro:property name="align_fr_deg" value="${[1.899, -0.046, 2.803]}"/>
+  <xacro:property name="align_rl_deg" value="${[-2.543, -0.005, -0.246]}"/>
+  <xacro:property name="align_rr_deg" value="${[2.932, 0.007, -0.290]}"/>
+  <!-- =========================================================================== -->
+  <xacro:property name="d2r" value="${pi / 180}"/>
+  <xacro:property name="align_fl" value="${align_fl_deg[0]*d2r} ${align_fl_deg[1]*d2r} ${align_fl_deg[2]*d2r}"/>
+  <xacro:property name="align_fr" value="${align_fr_deg[0]*d2r} ${align_fr_deg[1]*d2r} ${align_fr_deg[2]*d2r}"/>
+  <xacro:property name="align_rl" value="${align_rl_deg[0]*d2r} ${align_rl_deg[1]*d2r} ${align_rl_deg[2]*d2r}"/>
+  <xacro:property name="align_rr" value="${align_rr_deg[0]*d2r} ${align_rr_deg[1]*d2r} ${align_rr_deg[2]*d2r}"/>
 
   <material name="${car_name}_accent">
     <color rgba="$(arg accent_color)"/>
@@ -76,28 +100,48 @@
     </visual>
   </link>
 
-  <joint name="base_to_back_left_wheel" type="fixed">
+  <!-- Rear wheels hang off fixed hinge frames like the fronts do, so the bridge
+       can publish their rolling rotation (about y, the axle) as a plain TF. -->
+  <joint name="base_to_back_left_hinge" type="fixed">
     <parent link="${car_name}/base_link"/>
-    <child link="${car_name}/back_left_wheel"/>
+    <child link="${car_name}/back_left_hinge"/>
     <origin xyz="${s * -0.000833 - lr} ${s * 0.130772} ${s * 0.051076}"/>
+  </joint>
+
+  <link name="${car_name}/back_left_hinge"/>
+
+  <joint name="back_left_hinge_to_wheel" type="continuous">
+    <parent link="${car_name}/back_left_hinge"/>
+    <child link="${car_name}/back_left_wheel"/>
+    <axis xyz="0 1 0"/>
   </joint>
 
   <link name="${car_name}/back_left_wheel">
     <visual>
+      <origin rpy="${align_rl}"/>
       <geometry>
         <mesh filename="${mesh_dir}/roboracer_wheel_rear_left.glb" scale="${s} ${s} ${s}"/>
       </geometry>
     </visual>
   </link>
 
-  <joint name="base_to_back_right_wheel" type="fixed">
+  <joint name="base_to_back_right_hinge" type="fixed">
     <parent link="${car_name}/base_link"/>
-    <child link="${car_name}/back_right_wheel"/>
+    <child link="${car_name}/back_right_hinge"/>
     <origin xyz="${s * 0.000833 - lr} ${s * -0.132075} ${s * 0.050856}"/>
+  </joint>
+
+  <link name="${car_name}/back_right_hinge"/>
+
+  <joint name="back_right_hinge_to_wheel" type="continuous">
+    <parent link="${car_name}/back_right_hinge"/>
+    <child link="${car_name}/back_right_wheel"/>
+    <axis xyz="0 1 0"/>
   </joint>
 
   <link name="${car_name}/back_right_wheel">
     <visual>
+      <origin rpy="${align_rr}"/>
       <geometry>
         <mesh filename="${mesh_dir}/roboracer_wheel_rear_right.glb" scale="${s} ${s} ${s}"/>
       </geometry>
@@ -122,6 +166,7 @@
 
   <link name="${car_name}/front_left_wheel">
     <visual>
+      <origin rpy="${align_fl}"/>
       <geometry>
         <mesh filename="${mesh_dir}/roboracer_wheel_front_left.glb" scale="${s} ${s} ${s}"/>
       </geometry>
@@ -144,6 +189,7 @@
 
   <link name="${car_name}/front_right_wheel">
     <visual>
+      <origin rpy="${align_fr}"/>
       <geometry>
         <mesh filename="${mesh_dir}/roboracer_wheel_front_right.glb" scale="${s} ${s} ${s}"/>
       </geometry>


### PR DESCRIPTION
## Summary

Follow-up to #56 and the roboracer mesh model — three things, in three commits:

### 1. Wheels spin at the car's actual rolling rate
- The bridge integrates a per-car wheel angle from the sim's longitudinal speed (no-slip `v/r` — the ST model carries no wheel-speed states) and publishes it on the wheel TFs: fronts get steering (z) composed with roll about the steered axle, rears pure roll. Verified headless: measured 19.63 rad/s at 1.000 m/s vs 19.61 predicted, and the same at other speeds per-car independently.
- Rear wheels move from `fixed` joints onto the same hinge pattern the fronts use (fixed `base->hinge` at the hub + `continuous` `hinge->wheel` about y), so the bridge can animate them without fighting robot_state_publisher's static TF. Link names are unchanged; the new `back_*_hinge` frames are additions.
- Wheel radius (0.051 m) is measured from the wheel glbs and scaled per platform by the same wheelbase factors the xacro applies.

### 2. Mesh alignment + launch robustness
- The four wheel glbs are baked from one source wheel at its **posed orientation in the USD scene**, so each carries a different camber+toe tilt off its true axle (front-left is 4.2° total, incl. >2° of toe). Standing still that reads as crooked wheels; spinning, any residual angle between mesh axle and the spin axis becomes a visible wobble cone. Each wheel visual now gets an exact per-wheel rpy counter-rotation, measured from the mesh vertices by the new `scripts/measure_wheel_alignment.py` (PCA — the axle is the thin principal axis). If `usd_to_mesh.py` is ever taught to bake wheels in a canonical axle-on-y pose, these corrections all become zero — until then, rerun the script after re-exporting.
- `robot_description` is now wrapped in `ParameterValue(value_type=str)`. Launch yaml-parses bare `Command` parameter values, so any `colon + space` in the xacro output aborted the whole launch ("Unable to parse the value of parameter robot_description as yaml") while already-spawned nodes lived on as orphans.
- New `display.launch.xml`: the mesh URDF alone with `joint_state_publisher_gui` sliders + RViz for inspecting joints and alignment without the sim (`car_name`/`vehicle` args; adds the `joint_state_publisher_gui` dependency).

### 3. Up to 8 cars out of the box
- `sim.yaml` now ships start poses for **eight cars** (two rows of four on Levine), so anything up to `num_agent:=8` runs without touching the config — verified: eight cars spawn and drive independently. README updated; the shipped Foxglove layout still draws the first four, extra opponents need a robot-description entry per car as documented.

## Testing
- Headless: spin rate matches `v/r` exactly per car; steering angle decomposes correctly on front wheel TFs; static hinge TFs at the exact hub offsets; `num_agent:=8` spawns all cars at their configured poses and each drives independently on its own topic.
- Visual (Foxglove, `meshUpAxis: z_up` layout): all four wheels stand straight and roll without wobble, front and rear; verified after the per-wheel alignment.